### PR TITLE
Adds is_video property to Sticker type

### DIFF
--- a/src/types/Sticker.ts
+++ b/src/types/Sticker.ts
@@ -44,6 +44,11 @@ export type Sticker = {
   is_voice: boolean;
 
   /**
+   * True, if the sticker is a video sticker
+   */
+  is_video: boolean;
+
+  /**
    * Optional. Sticker thumbnail in the .WEBP or .JPG format
    */
   thumbnail?: PhotoSize;


### PR DESCRIPTION
Adds the `is_video` boolean property to the `Sticker` type definition.

This property indicates whether a sticker is a video sticker.